### PR TITLE
fix: compile multiple <script> block in custom tag

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -206,7 +206,7 @@ function compile(src, opts) {
       if (!js.trim()) {
         html = html.replace(SCRIPT, function(_, _type, script) {
           if (_type) type = _type.replace('text/', '')
-          js = script
+          js += script
           return ''
         })
       }


### PR DESCRIPTION
When custom tag includes multiple <script> block, non last <script> ignored.
Fix it.