### PR TITLE
v2.3.0-beta.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
 install:
   - npm i jade
   - npm i babel-core
+  - npm i babel-preset-es2015
   - npm i coffee-script
   - npm i livescript
   - npm i typescript-simple

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
 
 `$ bower install riot-compiler --save`
 
+### For babel users
+
+From v2.3.0-beta.6, `compiler.parsers.css.es6` supports `babel-core` only, and its new API, you need also `npm install babel-preset-es2015` for this works. Temporal support for babel version 5.8.x is through the `compiler.parsers.css.babel` (`<script type="babel">`). It is recommended that you update your installation of babel as soon as possible.
+
+
 [travis-image]:https://img.shields.io/travis/riot/compiler.svg?style=flat-square
 [travis-url]:https://travis-ci.org/riot/compiler
 [license-image]:http://img.shields.io/badge/license-MIT-000000.svg?style=flat-square

--- a/dist/compiler.js
+++ b/dist/compiler.js
@@ -1,4 +1,4 @@
-/* riot-compiler 2.3.0-beta.5, @license MIT, (c) 2015 Muut Inc. + contributors */
+/* riot-compiler 2.3.0-beta.6, @license MIT, (c) 2015 Muut Inc. + contributors */
 ;(function (root, factory) {
 
   /* istanbul ignore else */
@@ -35,9 +35,8 @@
 
       switch (name) {
       case 'es6':
-      // istanbul ignore next: we have babel-core in test
-      case 'babel':
-        return fn('babel-core') || fn('babel')
+        req = 'babel-core'
+        break
       case 'none':
       case 'javascript':
         return _js.none
@@ -87,6 +86,11 @@
       },
       es6: function (js) {
         return _req('es6').transform(js, {
+          presets: ['es2015'], ast: false, sourceMaps: false, comments: false
+        }).code
+      },
+      babel: /* istanbul ignore next */ function (js) {
+        return _req('babel').transform(js, {
           blacklist: ['useStrict', 'react'], sourceMaps: false, comments: false
         }).code
       },
@@ -95,7 +99,6 @@
       }
     }
 
-    _js.babel        = _js.es6
     _js.javascript   = _js.none
     _js.coffeescript = _js.coffee
 
@@ -349,7 +352,6 @@
       else if (parsers.css[type]) {
         style = parsers.css[type](tag, style)
       }
-      // istanbul ignore else: fallback to nothing
       else if (type !== 'css') {
         throw new Error('CSS parser not found: "' + type + '"')
       }

--- a/dist/riot.compiler.js
+++ b/dist/riot.compiler.js
@@ -1,7 +1,7 @@
 
 /**
  * Compiler for riot custom tags
- * @version 2.3.0-beta.5
+ * @version 2.3.0-beta.6
  */
 
 /**
@@ -58,6 +58,11 @@ var parsers = (function () {
     },
     es6: function (js) {
       return _req('es6').transform(js, {
+        presets: ['es2015'], ast: false, sourceMaps: false, comments: false
+      }).code
+    },
+    babel: /* istanbul ignore next */ function (js) {
+      return _req('babel').transform(js, {
         blacklist: ['useStrict', 'react'], sourceMaps: false, comments: false
       }).code
     },
@@ -66,7 +71,6 @@ var parsers = (function () {
     }
   }
 
-  _js.babel        = _js.es6
   _js.javascript   = _js.none
   _js.coffeescript = _js.coffee
 
@@ -321,7 +325,6 @@ var compile = (function () {
       else if (parsers.css[type]) {
         style = parsers.css[type](tag, style)
       }
-      // istanbul ignore else: fallback to nothing
       else if (type !== 'css') {
         throw new Error('CSS parser not found: "' + type + '"')
       }

--- a/lib/core.js
+++ b/lib/core.js
@@ -352,7 +352,6 @@ var compile = (function () {
       else if (parsers.css[type]) {
         style = parsers.css[type](tag, style)
       }
-      // istanbul ignore else: fallback to nothing
       else if (type !== 'css') {
         throw new Error('CSS parser not found: "' + type + '"')
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 //#if NODE
 //#undef RIOT
-/* riot-compiler 2.3.0-beta.5, @license MIT, (c) 2015 Muut Inc. + contributors */
+/* riot-compiler 2.3.0-beta.6, @license MIT, (c) 2015 Muut Inc. + contributors */
 ;(function (root, factory) {
 
   /* istanbul ignore else */
@@ -22,7 +22,7 @@
 
 /**
  * Compiler for riot custom tags
- * @version 2.3.0-beta.5
+ * @version 2.3.0-beta.6
  */
 //#endif
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -24,9 +24,8 @@ var parsers = (function () {
 
     switch (name) {
     case 'es6':
-    // istanbul ignore next: we have babel-core in test
-    case 'babel':
-      return fn('babel-core') || fn('babel')
+      req = 'babel-core'
+      break
     case 'none':
     case 'javascript':
       return _js.none
@@ -97,6 +96,11 @@ var parsers = (function () {
     },
     es6: function (js) {
       return _req('es6').transform(js, {
+        presets: ['es2015'], ast: false, sourceMaps: false, comments: false
+      }).code
+    },
+    babel: /* istanbul ignore next */ function (js) {
+      return _req('babel').transform(js, {
         blacklist: ['useStrict', 'react'], sourceMaps: false, comments: false
       }).code
     },
@@ -105,7 +109,6 @@ var parsers = (function () {
     }
   }
 
-  _js.babel        = _js.es6
   _js.javascript   = _js.none
   _js.coffeescript = _js.coffee     // 4 the nostalgics
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-compiler",
-  "version": "2.3.0-beta.5",
+  "version": "2.3.0-beta.6",
   "description": "Compiler for riot .tag files",
   "main": "dist/compiler.js",
   "directories": {

--- a/test/specs/expect/html-block1.js
+++ b/test/specs/expect/html-block1.js
@@ -1,6 +1,0 @@
-//src: html-block1.tag
-riot.tag2('html-block1', '', '', '', function(opts) {
-
-  var n = x <y && y>
-    z
-});

--- a/test/specs/expect/html-block2.js
+++ b/test/specs/expect/html-block2.js
@@ -1,5 +1,0 @@
-//src: html-block2.tag
-riot.tag2('html-block2', '<input>', '', '', function(opts) {
-  var n = x<1, 5>
-    z
-});

--- a/test/specs/expect/html-blocks.js
+++ b/test/specs/expect/html-blocks.js
@@ -1,0 +1,12 @@
+//src: html-blocks.tag
+// <y && y> can be confused with a closing html tag
+
+riot.tag2('html-block1', '', '', '', function(opts) {
+  var n = x <y && y>
+    z
+});
+
+riot.tag2('html-block2', '<input>', '', '', function(opts) {
+  var n = x<1 ,5 >
+    z
+});

--- a/test/specs/fixtures/html-block1.tag
+++ b/test/specs/fixtures/html-block1.tag
@@ -1,4 +1,0 @@
-<html-block1> <!-- <y && y> can be taken as closing html tag? -->
-  var n = x <y && y>
-    z
-</html-block1>

--- a/test/specs/fixtures/html-block2.tag
+++ b/test/specs/fixtures/html-block2.tag
@@ -1,5 +1,0 @@
-<html-block2> <!-- <y && y> can be taken as closing html tag? -->
-  <input>
-  var n = x<1, 5>
-    z
-</html-block2>

--- a/test/specs/fixtures/html-blocks.tag
+++ b/test/specs/fixtures/html-blocks.tag
@@ -1,0 +1,12 @@
+// <y && y> can be confused with a closing html tag
+
+<html-block1>
+  var n = x <y && y>
+    z
+</html-block1>
+
+<html-block2>
+  <input>
+  var n = x<1 ,5 >
+    z
+</html-block2>

--- a/test/specs/parsers/js/test-attr.es6.js
+++ b/test/specs/parsers/js/test-attr.es6.js
@@ -1,2 +1,2 @@
-riot.tag2('es6', '<div class="{className: true}">Hello</div>', '', '', function(opts) {
+riot.tag2('es6', '<div class="{className: true}" str="{className: true}" foo="{&quot;foo&quot; + bar}">Hello</div>', '', '', function(opts) {
 }, '{ }');

--- a/test/specs/parsers/suite.js
+++ b/test/specs/parsers/suite.js
@@ -40,7 +40,7 @@ function testParser(name, opts) {
 
 describe('HTML parsers', function () {
 
-  this.timeout(10000)
+  this.timeout(12000)
 
   function testStr(str, resStr, opts) {
     expect(compiler.html(str, opts || {})).to.be(resStr)
@@ -92,7 +92,7 @@ describe('HTML parsers', function () {
 
 describe('JavaScript parsers', function () {
 
-  this.timeout(10000)
+  this.timeout(20000) // first call to babel-core is slooooow!
 
   // complex.tag
   it('complex tag structure', function () {
@@ -141,7 +141,7 @@ describe('JavaScript parsers', function () {
   })
 
   // testParser.es6.tag
-  it('es6 (babel-core or babel)', function () {
+  it('es6 (babel-core 6.0.2+)', function () {
     if (have('es6')) {
       testParser('test', { type: 'es6' })
     }
@@ -149,7 +149,7 @@ describe('JavaScript parsers', function () {
 
   // testParser-attr.es6.tag
   it('es6 with shorthands (fix #1090)', function () {
-    if (have('babel')) {
+    if (have('es6')) {
       testParser('test-attr', { type: 'es6', expr: true })
     }
   })
@@ -159,7 +159,7 @@ describe('JavaScript parsers', function () {
 
 describe('Style parsers', function () {
 
-  this.timeout(10000)
+  this.timeout(12000)
 
   function _sass(tag, css) {
     return '' + compiler.parsers._req('sass').renderSync({

--- a/test/specs/parsers/test-attr.es6.tag
+++ b/test/specs/parsers/test-attr.es6.tag
@@ -1,4 +1,4 @@
 
 <es6>   <!-- fix to riot #1090 -->
-    <div class={^ className: true }>Hello</div>
+    <div class={^ className: true } str={ className: true } foo={ `foo${ bar }` }>Hello</div>
 </es6>

--- a/test/specs/riotjs.js
+++ b/test/specs/riotjs.js
@@ -1,7 +1,7 @@
+var fs = require('fs'),
+  path = require('path')
+
 describe('riotjs', function () {
-  var
-    path = require('path'),
-    fs = require('fs')
 
   function render(str) {
     return compiler.js(str, {})

--- a/test/specs/scoped-css.js
+++ b/test/specs/scoped-css.js
@@ -24,7 +24,7 @@ describe('Scoped CSS', function() {
     expect(render('i[class=twitter] { background: #55ACEE }'))
         .to.equal('my-tag i[class=twitter],[riot-tag="my-tag"] i[class=twitter] { background: #55ACEE }')
   })
-  it('add my-tag to the selector with a backslash', function() {
+  it('add my-tag to the selector with a pseudo-class', function() {
     expect(render('a:after { content: "*" }'))
         .to.equal('my-tag a:after,[riot-tag="my-tag"] a:after { content: "*" }')
   })
@@ -40,7 +40,7 @@ describe('Scoped CSS', function() {
     expect(render(':scope > ul { padding: 0 }'))
         .to.equal('my-tag > ul,[riot-tag="my-tag"] > ul { padding: 0 }')
   })
-  it('add my-tag to the root selector with attr', function() {
+  it('add my-tag to the root selector with attribute', function() {
     expect(render(':scope[disabled] { color: gray }'))
         .to.equal('my-tag[disabled],[riot-tag="my-tag"][disabled] { color: gray }')
   })
@@ -60,7 +60,7 @@ describe('Scoped CSS', function() {
     expect(render('@keyframes fade { from { opacity: 1; } to { opacity: 0; } }'))
         .to.equal('@keyframes fade { from { opacity: 1; } to { opacity: 0; } }')
   })
-  it('not add my-tag to parsentage values in @keyframes', function() {
+  it('not add my-tag to parcentage values in @keyframes', function() {
     expect(render('@keyframes fade { 10% { opacity: 1; } 85% { opacity: 0; } }'))
         .to.equal('@keyframes fade { 10% { opacity: 1; } 85% { opacity: 0; } }')
   })

--- a/test/specs/tag.js
+++ b/test/specs/tag.js
@@ -1,9 +1,7 @@
-describe('Compile tags', function() {
-  var
-    path = require('path'),
-    fs = require('fs')
+var fs = require('fs'),
+  path = require('path')
 
-  //var basedir = path.join(__dirname, 'fixtures')
+describe('Compile tags', function() {
 
   // adding some custom riot parsers
   // css
@@ -16,7 +14,7 @@ describe('Compile tags', function() {
   }
 
   function render(str, name) {
-    return compiler.compile(str, /*{ basedir: basedir }*/{}, name)
+    return compiler.compile(str, {}, name)
   }
 
   function cat(dir, filename) {
@@ -24,8 +22,7 @@ describe('Compile tags', function() {
   }
 
   function testFile(name) {
-    var
-      src = cat('fixtures', name + '.tag'),
+    var src = cat('fixtures', name + '.tag'),
       js = render(src, name + '.tag')
 
     expect(js).to.equal(cat('expect', name + '.js'))
@@ -55,13 +52,12 @@ describe('Compile tags', function() {
     testFile('box')
   })
 
-  it('More freedom in the format (v2.3)', function() {
+  it('Flexible method style (v2.3)', function() {
     testFile('free-style')
   })
 
   it('Detect some fake closing html tags', function () {
-    testFile('html-block1')
-    testFile('html-block2')
+    testFile('html-blocks')
   })
 
   it('The treeview question', function () {


### PR DESCRIPTION
Breaking change:

`compiler.parsers.css.es6` is for babel-core only, because changes in the its API. You need install `babel-preset-es2015` too.

new `compiler.parsers.css.babel` is for old babel 5.8.x