### PR TITLE
fixed the parsers function passing the always url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,29 @@ install:
   - npm i jade
   - npm i babel@5.8
   - npm i babel-core
-  - npm i babel-preset-es2015
+
+ # babel presets
+  - npm i babel-plugin-transform-es2015-template-literals
+  - npm i babel-plugin-transform-es2015-literals
+  - npm i babel-plugin-transform-es2015-function-name
+  - npm i babel-plugin-transform-es2015-arrow-functions
+  - npm i babel-plugin-transform-es2015-block-scoped-functions
+  - npm i babel-plugin-transform-es2015-classes
+  - npm i babel-plugin-transform-es2015-object-super
+  - npm i babel-plugin-transform-es2015-shorthand-properties
+  - npm i babel-plugin-transform-es2015-computed-properties
+  - npm i babel-plugin-transform-es2015-for-of
+  - npm i babel-plugin-transform-es2015-sticky-regex
+  - npm i babel-plugin-transform-es2015-unicode-regex
+  - npm i babel-plugin-check-es2015-constants
+  - npm i babel-plugin-transform-es2015-spread
+  - npm i babel-plugin-transform-es2015-parameters
+  - npm i babel-plugin-transform-es2015-destructuring
+  - npm i babel-plugin-transform-es2015-block-scoping
+  - npm i babel-plugin-transform-es2015-typeof-symbol
+  - npm i babel-plugin-transform-es2015-modules-commonjs
+  - npm i babel-plugin-transform-regenerator
+
   - npm i coffee-script
   - npm i livescript
   - npm i typescript-simple

--- a/dist/riot.compiler.js
+++ b/dist/riot.compiler.js
@@ -31,13 +31,31 @@ var parsers = (function () {
   }
 
   var _html = {
-    jade: function (html, opts) {
-      return _req('jade').render(html, extend({pretty: true, doctype: 'html'}, opts))
+    jade: function (html, opts, url) {
+      return _req('jade').render(html, extend({
+        pretty: true,
+        filename: url,
+        doctype: 'html'
+      }, opts))
     }
   }
 
   var _css = {
-    stylus: function (tag, css, opts) {
+    less: function(tag, css, opts, url) {
+      var less = _req('less'),
+        ret
+
+      less.render(css, extend({
+        sync: true,
+        compress: true
+      }, opts), function (err, result) {
+        // istanbul ignore next
+        if (err) throw err
+        ret = result.css
+      })
+      return ret
+    },
+    stylus: function (tag, css, opts, url) {
       var
         stylus = _req('stylus'), nib = _req('nib')
       /* istanbul ignore next: can't run both */
@@ -47,29 +65,28 @@ var parsers = (function () {
   }
 
   var _js = {
-    none: function (js, opts) {
+    none: function (js, opts, url) {
       return js
     },
-    livescript: function (js, opts) {
+    livescript: function (js, opts, url) {
       return _req('livescript').compile(js, extend({bare: true, header: false}, opts))
     },
-    typescript: function (js, opts) {
+    typescript: function (js, opts, url) {
       return _req('typescript')(js, opts).replace(/\r\n?/g, '\n')
     },
-    es6: function (js, opts) {
+    es6: function (js, opts, url) {
       return _req('es6').transform(js, extend({
         blacklist: ['useStrict', 'strict', 'react'], sourceMaps: false, comments: false
       }, opts)).code
     },
-    babel: function (js, opts) {
-      js = 'function __parser_babel_wrapper__(){' + js + '}'
+    babel: function (js, opts, url) {
       return _req('babel').transform(js,
         extend({
-          presets: ['es2015']
+          filename: url
         }, opts)
-      ).code.replace(/["']use strict["'];[\r\n]+/, '').slice(38, -2)
+      ).code
     },
-    coffee: function (js, opts) {
+    coffee: function (js, opts, url) {
       return _req('coffee').compile(js, extend({bare: true}, opts))
     }
   }
@@ -216,7 +233,7 @@ var compile = (function () {
     HTML_COMMENT = /<!--(?!>)[\S\s]*?-->/g,
     HTML_TAGS = /<([-\w]+)\s*([^"'\/>]*(?:(?:"[^"]*"|'[^']*'|\/[^>])[^'"\/>]*)*)(\/?)>/g
 
-  function compileHTML(html, opts, pcex, intc) {
+  function compileHTML(html, opts, pcex, intc, url) {
 
     if (!intc) {
       _bp = brackets.array(opts.brackets)
@@ -299,7 +316,7 @@ var compile = (function () {
     }
   }
 
-  function compileJS(js, opts, type, parserOpts) {
+  function compileJS(js, opts, type, parserOpts, url) {
     if (!js) return ''
     if (!type) type = opts.type
 
@@ -307,7 +324,7 @@ var compile = (function () {
     if (!parser)
       throw new Error('JS parser not found: "' + type + '"')
 
-    return parser(js, parserOpts).replace(TRIM_TRAIL, '')
+    return parser(js, parserOpts, url).replace(TRIM_TRAIL, '')
   }
 
   var CSS_SELECTOR = _regEx('(}|{|^)[ ;]*([^@ ;{}][^{}]*)(?={)|' + brackets.R_STRINGS.source, 'g')
@@ -401,7 +418,7 @@ var compile = (function () {
         file = path.resolve(path.dirname(url), src)
       code = require('fs').readFileSync(file, {encoding: charset || 'utf8'})
     }
-    return compileJS(code, opts, type, parserOpts)
+    return compileJS(code, opts, type, parserOpts, url)
   }
 
   // Matches HTML tag ending a line. This regex still can be fooled by code as:
@@ -468,7 +485,9 @@ var compile = (function () {
     if (opts.template)
       src = compileTemplate(opts.template, src, opts.templateOptions)
 
-    label = url ? '//src: ' + url + '\n' : ''
+    if (opts.debug && url) {
+      label = '//src: ' + url + '\n'
+    } else label = ''
 
     src = label + src
       .replace(/\r\n?/g, '\n')
@@ -491,7 +510,7 @@ var compile = (function () {
 
           if (body2) {
             /* istanbul ignore next */
-            html = included('html') ? compileHTML(body2, opts, pcex, 1) : ''
+            html = included('html') ? compileHTML(body2, opts, pcex, 1, url) : ''
           }
           else {
             body = body.replace(_regEx('^' + indent, 'gm'), '')
@@ -501,7 +520,7 @@ var compile = (function () {
                 var scoped = _attrs && /\sscoped(\s|=|$)/i.test(_attrs),
                   csstype = getType(_attrs) || opts.style
                 styles += (styles ? ' ' : '') +
-                  compileCSS(_style, tagName, csstype, scoped, getParserOptions(_attrs))
+                  compileCSS(_style, tagName, csstype, scoped, getParserOptions(_attrs), url)
                 return ''
               })
             }
@@ -518,13 +537,13 @@ var compile = (function () {
             if (included('html')) {
               body = blocks[0]
               if (body)
-                html = compileHTML(body, opts, pcex, 1)
+                html = compileHTML(body, opts, pcex, 1, url)
             }
 
             if (included('js')) {
               body = blocks[1]
               if (/\S/.test(body))
-                jscode += (jscode ? '\n' : '') + compileJS(body, opts)
+                jscode += (jscode ? '\n' : '') + compileJS(body, opts, null, null, url)
             }
           }
         }

--- a/lib/core.js
+++ b/lib/core.js
@@ -199,7 +199,7 @@ var compile = (function () {
    * @returns {string} The parsed HTML text
    * @see http://www.w3.org/TR/html5/syntax.html
    */
-  function compileHTML(html, opts, pcex, intc) {
+  function compileHTML(html, opts, pcex, intc, url) {
 
     // `_bp`is undefined when `compileHTML` is called from tests
     if (!intc) {
@@ -306,7 +306,7 @@ var compile = (function () {
    * @param   {Object} parserOpts - Optional parser options
    * @returns {string} The parsed JavaScript code
    */
-  function compileJS(js, opts, type, parserOpts) {
+  function compileJS(js, opts, type, parserOpts, url) {
     if (!js) return ''
     if (!type) type = opts.type
 
@@ -314,7 +314,7 @@ var compile = (function () {
     if (!parser)
       throw new Error('JS parser not found: "' + type + '"')
 
-    return parser(js, parserOpts).replace(TRIM_TRAIL, '')
+    return parser(js, parserOpts, url).replace(TRIM_TRAIL, '')
   }
 
 
@@ -439,7 +439,7 @@ var compile = (function () {
         file = path.resolve(path.dirname(url), src)
       code = require('fs').readFileSync(file, {encoding: charset || 'utf8'})
     }
-    return compileJS(code, opts, type, parserOpts)
+    return compileJS(code, opts, type, parserOpts, url)
   }
 
   // Matches HTML tag ending a line. This regex still can be fooled by code as:
@@ -534,15 +534,16 @@ var compile = (function () {
       src = compileTemplate(opts.template, src, opts.templateOptions)
 
     // riot #1070 -- isAbsolute does not exists in node 10.x
-    //#if NODE
-    /* istanbul ignore next */
-    label = !url ? '' : path.isAbsolute(url) ? path.relative('.', url) : url
-    if (label)
-      label = '//src: ' + label.replace(/\\/g, '/') + '\n'
-    //#else
-    label = url ? '//src: ' + url + '\n' : ''
-    //#endif
-
+    if (opts.debug && url) {
+      //#if NODE
+      /* istanbul ignore next */
+      label = path.isAbsolute(url) ? path.relative('.', url) : url
+      if (label)
+        label = '//src: ' + label.replace(/\\/g, '/') + '\n'
+      //#else
+      label = '//src: ' + url + '\n'
+      //#endif
+    } else label = ''
     // normalize eols and start processing the tags
     src = label + src
       .replace(/\r\n?/g, '\n')
@@ -569,7 +570,7 @@ var compile = (function () {
 
           if (body2) {
             /* istanbul ignore next */
-            html = included('html') ? compileHTML(body2, opts, pcex, 1) : ''
+            html = included('html') ? compileHTML(body2, opts, pcex, 1, url) : ''
           }
           else {
             body = body.replace(_regEx('^' + indent, 'gm'), '')
@@ -580,7 +581,7 @@ var compile = (function () {
                 var scoped = _attrs && /\sscoped(\s|=|$)/i.test(_attrs),
                   csstype = getType(_attrs) || opts.style
                 styles += (styles ? ' ' : '') +
-                  compileCSS(_style, tagName, csstype, scoped, getParserOptions(_attrs))
+                  compileCSS(_style, tagName, csstype, scoped, getParserOptions(_attrs), url)
                 return ''
               })
             }
@@ -599,13 +600,13 @@ var compile = (function () {
             if (included('html')) {
               body = blocks[0]
               if (body)
-                html = compileHTML(body, opts, pcex, 1)
+                html = compileHTML(body, opts, pcex, 1, url)
             }
 
             if (included('js')) {
               body = blocks[1]
               if (/\S/.test(body))
-                jscode += (jscode ? '\n' : '') + compileJS(body, opts)
+                jscode += (jscode ? '\n' : '') + compileJS(body, opts, null, null, url)
             }
           }
         }

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -79,14 +79,18 @@ var parsers = (function () {
   //// The parsers object --
 
   var _html = {
-    jade: function (html, opts) {
-      return _req('jade').render(html, extend({pretty: true, doctype: 'html'}, opts))
+    jade: function (html, opts, url) {
+      return _req('jade').render(html, extend({
+        pretty: true,
+        filename: url,
+        doctype: 'html'
+      }, opts))
     }
   }
 
   var _css = {
     //#if NODE
-    sass: function(tag, css, opts) {    // there's no standard sass for browsers
+    sass: function(tag, css, opts, url) {    // there's no standard sass for browsers
       var sass = _req('sass')
 
       return sass.renderSync(extend({
@@ -96,7 +100,7 @@ var parsers = (function () {
         outputStyle: 'compact'
       }, opts)).css + ''
     },
-    scss: function(tag, css, opts) {    // there's no standard sass for browsers
+    scss: function(tag, css, opts, url) {    // there's no standard sass for browsers
       var sass = _req('sass')
 
       return sass.renderSync(extend({
@@ -106,7 +110,8 @@ var parsers = (function () {
         outputStyle: 'compact'
       }, opts)).css + ''
     },
-    less: function(tag, css, opts) {
+    //#endif
+    less: function(tag, css, opts, url) {
       var less = _req('less'),
         ret
 
@@ -120,8 +125,7 @@ var parsers = (function () {
       })
       return ret
     },
-    //#endif
-    stylus: function (tag, css, opts) {
+    stylus: function (tag, css, opts, url) {
       var
         stylus = _req('stylus'), nib = _req('nib') // optional nib support
       /* istanbul ignore next: can't run both */
@@ -131,29 +135,28 @@ var parsers = (function () {
   }
 
   var _js = {
-    none: function (js, opts) {
+    none: function (js, opts, url) {
       return js
     },
-    livescript: function (js, opts) {
+    livescript: function (js, opts, url) {
       return _req('livescript').compile(js, extend({bare: true, header: false}, opts))
     },
-    typescript: function (js, opts) {
+    typescript: function (js, opts, url) {
       return _req('typescript')(js, opts).replace(/\r\n?/g, '\n')
     },
-    es6: function (js, opts) {
+    es6: function (js, opts, url) {
       return _req('es6').transform(js, extend({
         blacklist: ['useStrict', 'strict', 'react'], sourceMaps: false, comments: false
       }, opts)).code
     },
-    babel: function (js, opts) {
-      js = 'function __parser_babel_wrapper__(){' + js + '}'
+    babel: function (js, opts, url) {
       return _req('babel').transform(js,
         extend({
-          presets: ['es2015']
+          filename: url
         }, opts)
-      ).code.replace(/["']use strict["'];[\r\n]+/, '').slice(38, -2)
+      ).code
     },
-    coffee: function (js, opts) {
+    coffee: function (js, opts, url) {
       return _req('coffee').compile(js, extend({bare: true}, opts))
     }
   }

--- a/test/specs/parsers/.babelrc
+++ b/test/specs/parsers/.babelrc
@@ -1,0 +1,25 @@
+{
+  "plugins": [
+    "transform-es2015-template-literals",
+    "transform-es2015-literals",
+    "transform-es2015-function-name",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-block-scoped-functions",
+    "transform-es2015-classes",
+    "transform-es2015-object-super",
+    "transform-es2015-shorthand-properties",
+    "transform-es2015-computed-properties",
+    "transform-es2015-for-of",
+    "transform-es2015-sticky-regex",
+    "transform-es2015-unicode-regex",
+    "check-es2015-constants",
+    "transform-es2015-spread",
+    "transform-es2015-parameters",
+    "transform-es2015-destructuring",
+    "transform-es2015-block-scoping",
+    "transform-es2015-typeof-symbol",
+    ["transform-es2015-modules-commonjs", { "allowTopLevelThis": true }],
+    ["transform-regenerator", { "async": false, "asyncGenerators": false }]
+  ]
+
+}

--- a/test/specs/parsers/js/test.babel.js
+++ b/test/specs/parsers/js/test.babel.js
@@ -1,4 +1,8 @@
 riot.tag2('babel', '<h3>{test}</h3>', '', '', function(opts) {
-  var type = 'JavaScript';
-  this.test = 'This is ' + type;
+'use strict';
+
+var _foo = require('foo');
+
+var type = 'JavaScript';
+this.test = 'This is ' + type;
 }, '{ }');

--- a/test/specs/parsers/suite.js
+++ b/test/specs/parsers/suite.js
@@ -35,7 +35,7 @@ function testParser(name, opts) {
     str1 = cat(basedir, file + '.tag'),
     str2 = cat(jsdir, file + '.js')
 
-  expect(normalize(compiler.compile(str1, opts || {}))).to.be(normalize(str2))
+  expect(normalize(compiler.compile(str1, opts || {}, basedir + '/' + file + '.tag'))).to.be(normalize(str2))
 }
 
 describe('HTML parsers', function () {

--- a/test/specs/parsers/test.babel.tag
+++ b/test/specs/parsers/test.babel.tag
@@ -3,6 +3,8 @@
 
   <h3>{ test }</h3>
 
+  import { bar } from 'foo'
+
   const type = 'JavaScript'
   this.test = `This is ${type}`
 

--- a/test/specs/tag.js
+++ b/test/specs/tag.js
@@ -19,7 +19,7 @@ describe('Compile tags', function() {
   }
 
   function render(str, name) {
-    return compiler.compile(str, {}, path.join(fixtures, name))
+    return compiler.compile(str, { debug: true }, path.join(fixtures, name))
   }
 
   function cat(dir, filename) {


### PR DESCRIPTION
This pull request fixes definitively the babel issues https://github.com/riot/compiler/issues/21 allowing our users to use any kind of babel setup. 
I asked support to the babel maintainers and they told me that babel reads recursively the first `.babelrc` file found from the `filename` value passed to the `transform` method. This means that generally [these presets]( https://github.com/appedemic/babel-preset-es2015-riot) should be enough to compile our tags (and it should be documented on our site), but eventually our users can use their own babel setup
I have also added the `debug` flag to enable/disable the "src comments" from the output.