### PR TITLE
Add logging when required module was not installed

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -28,7 +28,7 @@ function _req (name, req) {
     mod = _mods[name]
   } else {
     if (!req) req = REQPATH + (name === 'coffeescript' ? 'coffee' : name)
-    try { mod = require(req) } catch (_) {/**/}
+    try { mod = require(req) } catch (_) { console.log(_)  }
     _mods[name] = mod || null
   }
   return mod


### PR DESCRIPTION
I using Gulp + Webpack-stream + Tag-loader + Riot. Everything was fine until I want to use `less` as a parser. Gulp generates mystic errors:

```
Module build failed: TypeError: (intermediate value)(intermediate value) is not a function
    at Object._loadParser (project/node_modules/riot/node_modules/riot-compiler/lib/parsers.js:54:39)
    at _compileCSS (project/node_modules/riot/node_modules/riot-compiler/lib/compiler.js:540:30)
    at cssCode (project/node_modules/riot/node_modules/riot-compiler/lib/compiler.js:792:10)
    ...
    at Object.module.exports (project/node_modules/tag-loader/index.js:6:51)
```

This does not provide any insights on the problem and wasted quite some time for me to tap into the file and adding verbose logging to find out exact problem, turns out that I did not have `less` installed. Here I only added logging when required module does not exist. To prevent more problems like this, things like using assignment as an identifier:

```
      return (dest[name] = _req(name))(p1, p2, p3, p4)
```

...should be avoided too, as `intermediate value` is really annoying and hard to track down. I did not change this though, because the Exception was clear enough.