### PR TITLE
fixed #81 failed to extract es6 import statement starts with tab or contains tab before import

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -118,7 +118,7 @@ var SPEC_TYPES = /^"(?:number|date(?:time)?|time|month|email|color)\b/i
  * Matches the 'import' statement
  * @const {RegExp}
  */
-var IMPORT_STATEMENT = /^(?: )*(?:import)(?:(?:.*))*$/gm
+var IMPORT_STATEMENT = /^(?:\s)*(?:import)(?:(?:.*))*$/gm
 
 /**
  * Matches trailing spaces and tabs by line.

--- a/test/specs/fixtures/es6-import.tag
+++ b/test/specs/fixtures/es6-import.tag
@@ -3,7 +3,7 @@
 
     <script>
     import john from 'doe'
-    import foo from 'bar'
+	import foo from 'bar'
     import { foo, bar, baz } from 'foo.bar.baz'
 
     time(){

--- a/test/specs/helpers.js
+++ b/test/specs/helpers.js
@@ -3,6 +3,7 @@ module.exports = {
     return js
       .replace(/ = function\s+\(/g, ' = function(')
       .replace(/ { ?|{ /g, '{')
+      .replace(/\r\n/g, '\n')
       .replace(/\n\n+/g, '\n')
       .replace(/^\/\/src:.*\n/, '')
       .trim()


### PR DESCRIPTION
replace
```js
var IMPORT_STATEMENT = /^(?: )*(?:import)(?:(?:.*))*$/gm
```
with
```js
var IMPORT_STATEMENT = /^(?:\s)*(?:import)(?:(?:.*))*$/gm
```

other tweaks:
- updated `test/specs/fixtures/es6-import.tag`
- added `.replace(/\r\n/g, '\n')` in `test/specs/helpers.js` for EOL issue in windows OS