### PR TITLE
Update core.js import regex

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -130,7 +130,7 @@ var SPEC_TYPES = /^"(?:number|date(?:time)?|time|month|email|color)\b/i
  * Matches the 'import' statement
  * @const {RegExp}
  */
-var IMPORT_STATEMENT = /^\s*import(?:(\s|\S)*)['|"]/gm
+var IMPORT_STATEMENT = /^\s*import(?:(?:\s|[^\s'"])*)['|"].*\n?/gm
 
 /**
  * Matches trailing spaces and tabs by line.

--- a/test/specs/expect/es6-import-untagged.js
+++ b/test/specs/expect/es6-import-untagged.js
@@ -1,4 +1,4 @@
 import* as foo from 'doe'
-  import 'bar'
+import 'bar'
 riot.tag2('import-untagged', '<h1>Hello</h1>', '', '', function(opts) {
 });

--- a/test/specs/expect/es6-import.js
+++ b/test/specs/expect/es6-import.js
@@ -1,19 +1,19 @@
 import john from 'doe'
-    import foo from 'bar'
-    import { foo, bar, baz } from 'foo.bar.baz'
-    import {
-      foo,
-      bar,
-      baz
-    } from 'foo.bar.baz'
-    import {
-      foo,
-      bar,
-      baz } from 'foo.bar.baz'
+import foo from 'bar'
+import { foo, bar, baz } from 'foo.bar.baz'
+import {
+  foo,
+  bar,
+  baz
+} from 'foo.bar.baz'
+import {
+  foo,
+  bar,
+  baz } from 'foo.bar.baz'
 
-    import { foo,
-      bar,
-      baz } from 'foo.bar.baz'
+import { foo,
+  bar,
+  baz } from 'foo.bar.baz'
 riot.tag2('import', '<h1>Hello</h1>', '', '', function(opts) {
 
 

--- a/test/specs/fixtures/es6-import.tag
+++ b/test/specs/fixtures/es6-import.tag
@@ -2,22 +2,22 @@
     <h1>Hello</h1>
 
     <script>
-    import john from 'doe'
-    import foo from 'bar'
-    import { foo, bar, baz } from 'foo.bar.baz'
-    import {
-      foo,
-      bar,
-      baz
-    } from 'foo.bar.baz'
-    import {
-      foo,
-      bar,
-      baz } from 'foo.bar.baz'
+import john from 'doe'
+import foo from 'bar'
+import { foo, bar, baz } from 'foo.bar.baz'
+import {
+  foo,
+  bar,
+  baz
+} from 'foo.bar.baz'
+import {
+  foo,
+  bar,
+  baz } from 'foo.bar.baz'
 
-    import { foo,
-      bar,
-      baz } from 'foo.bar.baz'
+import { foo,
+  bar,
+  baz } from 'foo.bar.baz'
 
     time(){
         return Date()


### PR DESCRIPTION
Fixes issue #91 (New import regex is match incorrectly).

Preview of the regex in action:
https://regex101.com/r/Isww62/4

Changes:

1. Changed all groups to non-capturing.
2. Changed the non-white space part from ```\S``` to ```[^\s'"]``` to exclude quotes (the reason is explained in the change number 3).
3. Now we match a single instance of single or double quotes just once to find the beginning of the module name.
4. We find the end of the import matching the newlines located immediately after the previously found beginning of the module name (found in change 3).
5. Also changed the unit tests whitespace on those related to the imports. Everything is now aligned to the left on the fixtures and the expect files now don't need the weird indentation to match the results.