### PR TITLE
Adds support for css @apply rule

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -517,7 +517,7 @@ function compileJS (js, opts, type, userOpts) {
  * Matches CSS selectors, excluding those beginning with '@' and quoted strings.
  * @const {RegExp}
  */
-var CSS_SELECTOR = RegExp('([{}]|^)[ ;]*([^@ ;{}][^{}]*)(?={)|' + S_LINESTR, 'g')
+var CSS_SELECTOR = RegExp('([{}]|^)[; ]*((?:[^@ ;{}][^{}]*)?[^@ ;{}:] ?)(?={)|' + S_LINESTR, 'g')
 
 /**
  * Parses styles enclosed in a "scoped" tag (`scoped` was removed from HTML5).

--- a/test/specs/expect/css-apply.js
+++ b/test/specs/expect/css-apply.js
@@ -1,0 +1,3 @@
+//src: test/specs/fixtures/css-apply.tag
+riot.tag2('css-apply', '<p>should have riot color</p> <div>should be applied riot theme</p>', 'css-apply,[data-is="css-apply"]{ display: block; --riot-theme: { color: white; background-color: #F04; }; --riot-color: #F04; } css-apply p,[data-is="css-apply"] p{ border: solid 1px black; color: var(--riot-color); } css-apply div,[data-is="css-apply"] div{ @apply --riot-theme; }', '', function(opts) {
+});

--- a/test/specs/fixtures/css-apply.tag
+++ b/test/specs/fixtures/css-apply.tag
@@ -1,0 +1,22 @@
+<css-apply>
+  <p>should have riot color</p>
+  <div>should be applied riot theme</p>
+
+  <style>
+    :scope {
+      display: block;
+      --riot-theme: {
+        color: white;
+        background-color: #F04;
+      };
+      --riot-color: #F04;
+    }
+    p {
+      border: solid 1px black;
+      color: var(--riot-color);
+    }
+    div {
+      @apply --riot-theme;
+    }
+  </style>
+</css-apply>

--- a/test/specs/tag.js
+++ b/test/specs/tag.js
@@ -63,6 +63,10 @@ describe('Compile tags', function () {
     testFile('scoped')
   })
 
+  it('CSS @apply Rules', function () {
+    testFile('css-apply')
+  })
+
   it('Quotes before ending HTML bracket', function () {
     testFile('input-last')
   })


### PR DESCRIPTION
`@apply` rule is an way to apply a set of values (like a mixin).
https://tabatkins.github.io/specs/css-apply-rule/

In riot@3.0.1, it fails to convert css like this...:

```css
:scope {
  display: block;
  --riot-theme: { /* couldn't process this line properly */
    color: white;
    background-color: #F04;
  };
}
div {
  @apply --riot-theme;
}
```

This pr will fix the issue.