### PR TITLE
Fixed coffeescript failing to compile when coffeescript npm module is installed but coffee-script isn't

### DIFF
--- a/lib/parsers/coffee.js
+++ b/lib/parsers/coffee.js
@@ -7,8 +7,14 @@
   2016-03-09: Initital release
 */
 var
-  mixobj = require('./_utils').mixobj,
+  mixobj = require('./_utils').mixobj
+
+var parser
+try {
   parser = require('coffee-script')
+} catch (e) {
+  parser = require('coffeescript')
+}
 
 var defopts = {
   bare: true


### PR DESCRIPTION
There are two coffee script modules `coffeescript` and `coffee-script`.  The coffee script [docs](http://coffeescript.org/#installation) use  coffeescript, riot uses coffee-script. This PR allows the use of either.

