### PR TITLE
Use coffeescript instead coffee-script by default.

### DIFF
--- a/lib/parsers/coffee.js
+++ b/lib/parsers/coffee.js
@@ -11,9 +11,9 @@ var
 
 var parser
 try {
-  parser = require('coffee-script')
-} catch (e) {
   parser = require('coffeescript')
+} catch (e) {
+  parser = require('coffee-script')
 }
 
 var defopts = {


### PR DESCRIPTION
Official [CoffeeScript site](http://coffeescript.org/#top) recommends to use `coffeescript` (instead `coffee-script`) module name. And right now the riot-compiler installs old coffee-script (and a lot of other unused dependencies see #105) and uses it by default.

The PR changes default module for coffeescript from `coffee-script`into `coffeescript`.