### PR TITLE
Improve _mixobj to merge arrays & objects

### DIFF
--- a/lib/parsers/_utils.js
+++ b/lib/parsers/_utils.js
@@ -19,7 +19,13 @@ function _mixobj () {
       for (var key in source) {
         // istanbul ignore else
         if (hasOwnProp.call(source, key)) {
-          target[key] = source[key]
+          if (target[key] instanceof Array && source[key] instanceof Array) {
+            target[key] = target[key].concat(source[key])
+          } else if (typeof target[key] === 'object' && typeof source[key] === 'object') {
+            target[key] = Object.assign({}, target[key], source[key])
+          } else {
+            target[key] = source[key]
+          }
         }
       }
     }

--- a/lib/parsers/_utils.js
+++ b/lib/parsers/_utils.js
@@ -20,7 +20,7 @@ function _mixobj () {
         // istanbul ignore else
         if (hasOwnProp.call(source, key)) {
           if (target[key] instanceof Array && source[key] instanceof Array) {
-            target[key] = target[key].concat(source[key])
+            target[key] = target[key].concat(source[key].filter(item => target[key].indexOf(item) < 0))
           } else if (typeof target[key] === 'object' && typeof source[key] === 'object') {
             target[key] = Object.assign({}, target[key], source[key])
           } else {


### PR DESCRIPTION
The _mixobj util recognizes arrays & objects now and merges them instead of overriding the existing value.

Fixes #112 

@GianlucaGuarini would you please review and let me know what you think?