### PR TITLE
fixes https://github.com/riot/riot/issues/2726

### DIFF
--- a/src/generators/template/utils.js
+++ b/src/generators/template/utils.js
@@ -71,6 +71,25 @@ export function isGlobal({ scope, node }) {
 }
 
 /**
+ * Checks if the identifier of a given node exists in a scope
+ * @param {types.Node} node - node to search for the identifier
+ * @param {Scope} scope - scope where to search for the identifier
+ * @returns {boolean} true if the node identifier is defined in the given scope
+ */
+function nodeIdentifierExistsInScope(node, scope) {
+  let found = false // eslint-disable-line
+  types.visit(node, {
+    visitIdentifier(path) {
+      if (scope.lookup(path.node.name)) {
+        found = true
+      }
+      this.abort()
+    }
+  })
+  return found
+}
+
+/**
  * Replace the path scope with a member Expression
  * @param   { types.NodePath } path - containing the current node visited
  * @param   { types.Node } property - node we want to prefix with the scope identifier
@@ -111,7 +130,7 @@ function visitMemberExpression(path) {
       this.traverse(path.get('object'))
     } else if (path.value.computed) {
       this.traverse(path)
-    } else {
+    } else if (!nodeIdentifierExistsInScope(path.node, path.scope)) {
       replacePathScope(path, isThisExpression(path.node.object) ? path.node.property : path.node)
     }
   }

--- a/test/generators/template.spec.js
+++ b/test/generators/template.spec.js
@@ -119,9 +119,9 @@ describe('Generators - Template', () => {
         expect(renderExpr('foo.bar[Symbol]')).to.be.equal('scope.foo.bar[Symbol]')
       })
 
-      it.only('functions declaration', () => {
-        //expect(renderExpr('(foo) => bar + foo')).to.be.equal('(foo) => scope.bar + foo')
-        //expect(renderExpr('(foo) => (bar) => foo + bar + baz')).to.be.equal('(foo) => (bar) => foo + bar + scope.baz')
+      it('functions declaration', () => {
+        expect(renderExpr('(foo) => bar + foo')).to.be.equal('(foo) => scope.bar + foo')
+        expect(renderExpr('(foo) => (bar) => foo + bar + baz')).to.be.equal('(foo) => (bar) => foo + bar + scope.baz')
         expect(renderExpr('(foo) => (event) => foo + event.target.value + baz')).to.be.equal('(foo) => (event) => foo + event.target.value + scope.baz')
       })
 


### PR DESCRIPTION
It fixes the visitMemberExpression by only prefixing the identifier for the expression if it doesn't exist in scope.
It does that by traversing a `MemberExpression` looking for the left most `Identifier` and looking up for it's name in the given scope.

I'm not sure if this was exactly what you had in mind, but i'm okay with improving it accordingly to your suggestions.

Cheers