### PR TITLE
Fastest version of cloneDeep

### DIFF
--- a/src/utils/clone-deep.js
+++ b/src/utils/clone-deep.js
@@ -1,8 +1,24 @@
+/* eslint-disable */
 /**
  * Simple clone deep function, do not use it for classes or recursive objects!
  * @param   {*} source - possibily an object to clone
  * @returns {*} the object we wanted to clone
  */
 export default function cloneDeep(source) {
-  return JSON.parse(JSON.stringify(source))
+  if (typeof source !== 'object' || source == null) {
+    return source
+  }
+
+  const isArray = Array.isArray(source)
+  const clone = isArray ? [...source] : { ...source }
+
+  let key
+
+  for (key in clone) {
+    if (clone.hasOwnProperty(key)) {
+      clone[key] = cloneDeep(clone[key])
+    }
+  }
+
+  return clone
 }


### PR DESCRIPTION
Not sure that cloneDeep can strongly affect the compilation time, but JSON.Stringify is quite slow and the proposed version somewhere 2 times faster. But it is not always possible. 
If it doesn't make sense, just cancel this PR.