### PR TITLE
fix: attribute expressions with newlines or backslashes were compiled as string literals

### DIFF
--- a/src/generators/template/utils.js
+++ b/src/generators/template/utils.js
@@ -623,6 +623,36 @@ export function createArrayString(stringsArray) {
 }
 
 /**
+ * Generate the pure immutable string chunks from a RiotParser.Attr value.
+ * Mirrors generateLiteralStringChunksFromNode for text nodes, but slices the
+ * attribute value span and keeps its whitespace (no trimming, unlike text nodes
+ * where the outer whitespace is insignificant).
+ * @param   {RiotParser.Attr} node - riot parser attribute node
+ * @param   {string} sourceCode - original tag source code
+ * @returns {Array} array containing the immutable string chunks
+ */
+function generateLiteralStringChunksFromAttributeNode(node, sourceCode) {
+  const valueEnd = node.valueStart + node.value.length
+
+  return node.expressions
+    .reduce((chunks, expression, index) => {
+      const start = index ? node.expressions[index - 1].end : node.valueStart
+      chunks.push(
+        encodeHTMLEntities(sourceCode.substring(start, expression.start)),
+      )
+
+      // add the static tail that follows the last expression
+      if (index === node.expressions.length - 1)
+        chunks.push(
+          encodeHTMLEntities(sourceCode.substring(expression.end, valueEnd)),
+        )
+
+      return chunks
+    }, [])
+    .map((str) => (node.unescape ? unescapeChar(str, node.unescape) : str))
+}
+
+/**
  * Simple expression bindings might contain multiple expressions like for example: "class="{foo} red {bar}""
  * This helper aims to merge them into a template literal if it's necessary
  * @param   {RiotParser.Attr} node - riot parser node
@@ -642,26 +672,28 @@ export function mergeAttributeExpressions(node, sourceFile, sourceCode) {
     // if there are no node parts or there is just one item we just create a simple expression literal
     case !node.parts || node.parts.length === 1:
       return transformExpression(node.expressions[0], sourceFile, sourceCode)
-    default:
-      // merge the siblings expressions into a single array literal
-      return createArrayString(
-        [
-          // fold the expression parts into a single array
-          ...node.parts.reduce((acc, str) => {
-            const expression = node.expressions.find(
-              (e) => e.text.trim() === str,
-            )
-
-            return [
-              ...acc,
-              expression
-                ? transformExpression(expression, sourceFile, sourceCode)
-                : builders.literal(encodeHTMLEntities(str)),
-            ]
-          }, []),
-          // filter out invalid items that are not literal or have no value
-        ].filter((expr) => !isLiteral(expr) || expr.value),
+    default: {
+      const stringChunks = generateLiteralStringChunksFromAttributeNode(
+        node,
+        sourceCode,
       )
+      const stringsArray = stringChunks
+        .reduce((acc, str, index) => {
+          const expression = node.expressions[index]
+
+          return [
+            ...acc,
+            builders.literal(str),
+            expression
+              ? transformExpression(expression, sourceFile, sourceCode)
+              : nullNode(),
+          ]
+        }, [])
+        // filter out the empty literals and the trailing null expression
+        .filter((expr) => !isLiteral(expr) || expr.value)
+
+      return createArrayString(stringsArray)
+    }
   }
 }
 

--- a/src/generators/template/utils.js
+++ b/src/generators/template/utils.js
@@ -633,6 +633,8 @@ export function createArrayString(stringsArray) {
  */
 function generateLiteralStringChunksFromAttributeNode(node, sourceCode) {
   const valueEnd = node.valueStart + node.value.length
+  const chunk = (start, end) =>
+    encodeHTMLEntities(sourceCode.substring(start, end))
 
   return node.expressions
     .reduce((chunks, expression, index) => {
@@ -640,10 +642,10 @@ function generateLiteralStringChunksFromAttributeNode(node, sourceCode) {
 
       return [
         ...chunks,
-        encodeHTMLEntities(sourceCode.substring(start, expression.start)),
+        chunk(start, expression.start),
         // add the static tail that follows the last expression
         ...(index === node.expressions.length - 1
-          ? [encodeHTMLEntities(sourceCode.substring(expression.end, valueEnd))]
+          ? [chunk(expression.end, valueEnd)]
           : []),
       ]
     }, [])

--- a/src/generators/template/utils.js
+++ b/src/generators/template/utils.js
@@ -637,17 +637,15 @@ function generateLiteralStringChunksFromAttributeNode(node, sourceCode) {
   return node.expressions
     .reduce((chunks, expression, index) => {
       const start = index ? node.expressions[index - 1].end : node.valueStart
-      chunks.push(
+
+      return [
+        ...chunks,
         encodeHTMLEntities(sourceCode.substring(start, expression.start)),
-      )
-
-      // add the static tail that follows the last expression
-      if (index === node.expressions.length - 1)
-        chunks.push(
-          encodeHTMLEntities(sourceCode.substring(expression.end, valueEnd)),
-        )
-
-      return chunks
+        // add the static tail that follows the last expression
+        ...(index === node.expressions.length - 1
+          ? [encodeHTMLEntities(sourceCode.substring(expression.end, valueEnd))]
+          : []),
+      ]
     }, [])
     .map((str) => (node.unescape ? unescapeChar(str, node.unescape) : str))
 }

--- a/test/generators/template.spec.js
+++ b/test/generators/template.spec.js
@@ -583,6 +583,38 @@ describe('Generators - Template', () => {
       ).to.be.equal('bar-foo')
     })
 
+    it('Merge attribute expression spanning multiple lines with strings', () => {
+      const source = `<li class="base {foo
+  ? 'a'
+  : 'b'}"></li>`
+      const { template } = parse(source)
+      const input = simpleBinding(template, 'expr0', FAKE_SRC_FILE, source)
+      const output = evaluateOutput(input)
+      const expression = output.expressions[0]
+
+      expect(expression[BINDING_EVALUATE_KEY]({ foo: true })).to.be.equal(
+        'base a',
+      )
+      expect(expression[BINDING_EVALUATE_KEY]({ foo: false })).to.be.equal(
+        'base b',
+      )
+    })
+
+    it('Merge attribute expression containing a backslash with strings', () => {
+      const source = "<li class=\"base {/\\d/.test(value) ? 'y' : 'n'}\"></li>"
+      const { template } = parse(source)
+      const input = simpleBinding(template, 'expr0', FAKE_SRC_FILE, source)
+      const output = evaluateOutput(input)
+      const expression = output.expressions[0]
+
+      expect(expression[BINDING_EVALUATE_KEY]({ value: '5' })).to.be.equal(
+        'base y',
+      )
+      expect(expression[BINDING_EVALUATE_KEY]({ value: 'x' })).to.be.equal(
+        'base n',
+      )
+    })
+
     it('Multiple attribute expressions', () => {
       const source = '<li class={foo} id={bar}></li>'
       const { template } = parse(source)


### PR DESCRIPTION
### DISCLAIMER
I met this bug so many times during the usage of RiotJS and it bothered me since. I always worked around it because there is a way to avoid it but it forces me to write attributes in a single line or with weird formatting and I'm quite a perfectionist about formatting >,>
I met this error today as well and I honestly used Claude to investigate it. It initially proposed a minimal fix that was functional but conceptually different from the rest of the code, so I checked how we could make the same fix while keeping the same structure of the rest of the repo and found that we could have just mirror the structure of `mergeNodeExpressions` with some minimal changes.

I wanted to share my process since I read that last PR on riot [(3077)](https://github.com/riot/riot/pull/3077) where AI was used in a bad and arrogant way.
That PR made me think to open a discussion about the usage of AI in this project, however this bug came first.  
Let's consider to discuss it more thoroughly!

Anyway, this bug is real and the fix is working.
I'll just provide the in-depth analysis and steps produced by the AI.

---


## The bug

An expression inside an attribute value is compiled to a **plain string literal
instead of being evaluated** when it contains a newline or a backslash, *as long
as there is static text next to it in the same attribute*.

```riot
<!-- broken: rendered class is the literal `card {expanded ? ...}`, unevaluated -->
<div class="card {expanded
  ? 'card--open'
  : 'card--closed'}"></div>

<!-- broken too: any backslash trips it, e.g. a regex -->
<label title="user {/^\d+$/.test(id) ? 'numeric' : 'named'}"></label>
```

Live reproduction: https://plnkr.co/edit/CcNWzxN313oDoB3b

A single-line expression, or a multi-line expression that is the *whole* value
(no surrounding static text), both work — the latter takes a different branch.

## Root cause

`mergeAttributeExpressions` rebuilds the value from `node.parts` and re-associates
each part to its expression with `e.text.trim() === part`. But the parser stores
expression code in `parts` **escaped** (backslashes, then EOLs — this is
documented parser behaviour), while `e.text` stays **raw**. So any expression
carrying a newline or backslash fails the match and falls through to the
`builders.literal(...)` branch, i.e. it is emitted as a string.

The sibling text-node path (`mergeNodeExpressions`) doesn't have this problem: it
slices the static chunks from the source by expression offset and interleaves them
positionally, without any string matching.

## The fix

Rebuild the attribute value the same way the text-node path does — a new
`generateLiteralStringChunksFromAttributeNode` helper slices the static chunks by
expression offset, and the `default` branch interleaves them with
`transformExpression`, dropping `parts` and the fragile match (and all escaping)
entirely.

## Tests

Two cases added to `test/generators/template.spec.js` (a multi-line ternary and a
regex-bearing expression, each beside static text). Both fail on `main` and pass
with the fix; the full suite stays green.
